### PR TITLE
DTSPO-22751 Fix re-creation of roleassignment on containers

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -197,13 +197,10 @@ resource "vault_generic_secret" "administrator_creds" {
 EOT
 }
 
-data "azurerm_storage_container" "container" {
-  for_each             = { for idx, container in var.containers_list : container.name => container }
-  name                 = each.value.name
-  storage_account_name = azurerm_storage_account.main.name
-  depends_on = [
-    azurerm_storage_container.container
-  ]
+locals {
+  container_name_to_index = {
+    for idx, container in var.containers_list : container.name => idx
+  }
 }
 
 resource "azurerm_role_assignment" "container_roles" {
@@ -213,7 +210,7 @@ resource "azurerm_role_assignment" "container_roles" {
     if length(container.role_assignments) > 0
   }
 
-  scope                = data.azurerm_storage_container.container[each.value.name].resource_manager_id
+  scope                = azurerm_storage_container.container[local.container_name_to_index[each.value.name]].resource_manager_id
   role_definition_name = each.value.role_assignments[0].role_name
   principal_id         = each.value.role_assignments[0].object_id
 }


### PR DESCRIPTION
### Jira link

https://tools.hmcts.net/jira/browse/DTSPO-22751

### Change description

Fix - The lookup of resource_manager_id directly from azurerm_storage_container.container instead of data lookup as data lookup is read at apply time and this causes resource re-creation.

### Testing done

Tested and applied on PRX, PRP and PRD

### Checklist

<!-- Check each box by removing the space and adding an x, e.g. [x] -->

- [x] commit messages are meaningful and follow good commit message guidelines
- [ ] README and other documentation has been updated / added (if needed)
- [ ] tests have been updated / new tests has been added (if needed)
- [ ] Does this PR introduce a breaking change
